### PR TITLE
Fix: typo "role" -> "asset" for Event::EndElement

### DIFF
--- a/src/model_parser.rs
+++ b/src/model_parser.rs
@@ -204,7 +204,7 @@ impl ModelParser {
             else if el.name == "role" {
               self.in_role = 0;
             }
-            else if el.name == "role" {
+            else if el.name == "asset" {
               self.in_asset = 0;
             }
             else if el.name == "security_property" {


### PR DESCRIPTION
Hi Shamal,

I hope you're keeping well. I saw the new repo and thought I'd take a look and see what you were up to.

Whilst quickly skimming, I noticed what looks like a typo, so thought I'd send a PR. 

Best wishes,
Alex

PS. You might be interested in [Cyber Springboard](https://cyberspringboard.com/) which I've created. Card #238 is using Cairis.